### PR TITLE
Protect against empty heap.

### DIFF
--- a/cachey/cache.py
+++ b/cachey/cache.py
@@ -123,8 +123,12 @@ class Cache(object):
         self.total_bytes -= self.nbytes.pop(key)
 
     def _shrink_one(self):
-        key, score = self.heap.popitem()
+        try:
+            key, score = self.heap.popitem()
+        except IndexError:
+            return
         self.retire(key)
+        
         
     def resize(self, available_bytes):
         """ Resize the cache. 


### PR DESCRIPTION
I do not understand how this can happen, but we are seeing this stack trace:

```
../testenv/lib/python3.6/site-packages/nbodykit/tests/test_cache.py:19: in test_cache
    cache.cache.shrink()
/home/travis/miniconda/envs/test/lib/python3.6/site-packages/cachey/cache.py:139: in shrink
    self._shrink_one()
/home/travis/miniconda/envs/test/lib/python3.6/site-packages/cachey/cache.py:126: in _shrink_one
    key, score = self.heap.popitem()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <heapdict.heapdict object at 0x7f24b44e46d8>
    def popitem(self):
        """D.popitem() -> (k, v), remove and return the (key, value) pair with lowest\nvalue; but raise KeyError if D is empty."""
>       wrapper = self.heap[0]
E       IndexError: list index out of range
/home/travis/miniconda/envs/test/lib/python3.6/site-packages/heapdict.py:91: IndexError
```

This should fix the stack trace, but it is not clear to me how it can happen when the heap is empty yet total_bytes is not zero.