### PR TITLE
Cost zero division

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,128 @@
 *.pyc
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.pyc
 
+
+# VS Code
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cachey/cache.py
+++ b/cachey/cache.py
@@ -123,8 +123,12 @@ class Cache(object):
         self.total_bytes -= self.nbytes.pop(key)
 
     def _shrink_one(self):
-        key, score = self.heap.popitem()
+        try:
+            key, score = self.heap.popitem()
+        except IndexError:
+            return
         self.retire(key)
+        
         
     def resize(self, available_bytes):
         """ Resize the cache. 

--- a/cachey/cache.py
+++ b/cachey/cache.py
@@ -3,8 +3,8 @@ from .score import Scorer
 from heapdict import heapdict
 import time
 
-def cost(nbytes, time, zvalue=.5):
-    return float(time) / (nbytes if nbytes else zvalue) / 1e9
+def cost(nbytes, time):
+    return float(time) / (nbytes or 1) / 1e9
 
 
 def memo_key(args, kwargs):

--- a/cachey/cache.py
+++ b/cachey/cache.py
@@ -4,7 +4,7 @@ from heapdict import heapdict
 import time
 
 def cost(nbytes, time, zvalue=.5):
-    return float(time) / max(nbytes, zvalue) / 1e9
+    return float(time) / (nbytes if nbytes else zvalue) / 1e9
 
 
 def memo_key(args, kwargs):

--- a/cachey/cache.py
+++ b/cachey/cache.py
@@ -3,8 +3,8 @@ from .score import Scorer
 from heapdict import heapdict
 import time
 
-def cost(nbytes, time):
-    return float(time) / nbytes / 1e9
+def cost(nbytes, time, zvalue=.5):
+    return float(time) / max(nbytes, zvalue) / 1e9
 
 
 def memo_key(args, kwargs):

--- a/cachey/tests/test_cache.py
+++ b/cachey/tests/test_cache.py
@@ -1,16 +1,15 @@
 import sys
 from time import sleep
 
-import pytest
-
 from cachey import Cache, Scorer, nbytes
 
 from cachey.cache import cost
 
-def test_cost():
+
+def test_cost_with_zero_bytes():
 
     assert cost(200, 500) == 2.5e-09
-    assert cost(0, 500) == 5e-07
+    assert 0 <= cost(0, 500) <= 100
 
 
 def test_cache():
@@ -31,6 +30,7 @@ def test_cache():
     assert 'x' not in c
     assert not c.data
     assert not c.heap
+
 
 def test_cache_resize():
     c = Cache(available_bytes=nbytes(1) * 3)
@@ -54,6 +54,7 @@ def test_cache_resize():
     c.resize(available_bytes=nbytes(1) * 10)
 
     assert set(c.data) == set('x')
+
 
 def test_cache_scores_update():
     c = Cache(available_bytes=nbytes(1) * 2)
@@ -86,10 +87,12 @@ def test_memoize():
 
 def test_callbacks():
     hit_flag = [False]
+
     def hit(key, value):
         hit_flag[0] = (key, value)
 
     miss_flag = [False]
+
     def miss(key):
         miss_flag[0] = key
 

--- a/cachey/tests/test_cache.py
+++ b/cachey/tests/test_cache.py
@@ -1,7 +1,20 @@
 import sys
 from time import sleep
 
+import pytest
+
 from cachey import Cache, Scorer, nbytes
+
+from cachey.cache import cost
+
+def test_cost():
+
+    assert cost(5_000, 5) == 1e-12
+    assert cost(0, 5) == 1e-08
+    assert cost(0, 5, .1) == 5e-08
+
+    with pytest.raises(ZeroDivisionError):
+        cost(0, 5, 0) # Effectively disable max()
 
 
 def test_cache():

--- a/cachey/tests/test_cache.py
+++ b/cachey/tests/test_cache.py
@@ -9,7 +9,7 @@ from cachey.cache import cost
 
 def test_cost():
 
-    assert cost(5_000, 5) == 1e-12
+    assert cost(5000, 5) == 1e-12
     assert cost(0, 5) == 1e-08
     assert cost(0, 5, .1) == 5e-08
 

--- a/cachey/tests/test_cache.py
+++ b/cachey/tests/test_cache.py
@@ -9,12 +9,8 @@ from cachey.cache import cost
 
 def test_cost():
 
-    assert cost(5000, 5) == 1e-12
-    assert cost(0, 5) == 1e-08
-    assert cost(0, 5, .1) == 5e-08
-
-    with pytest.raises(ZeroDivisionError):
-        cost(0, 5, 0) # Effectively disable max()
+    assert cost(200, 500) == 2.5e-09
+    assert cost(0, 500) == 5e-07
 
 
 def test_cache():


### PR DESCRIPTION
Fix for bug #19.

Updated `cost()` to include a kwarg called `zvalue` which defaults to `0.5`. Changes should have little effect on existing calls.

It effectively prevents zero values for `nbytes` from creating a `ZeroDivisionError` by providing a nonzero value less than 1. The function still raises `ZeroDivisionError` if `zvalue==0`.

New return value: 
```python
time / (nbytes if nbytes else zvalue) / 1e9
```