### PR TITLE
Bump GHA setup-miniconda version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@16930e6
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           miniconda-version: latest


### PR DESCRIPTION
setup-miniconda v2 fixes some deprecations in GitHub Actions